### PR TITLE
new: manage multiple types by shop

### DIFF
--- a/lib/shopmarker/shopmarker.js
+++ b/lib/shopmarker/shopmarker.js
@@ -68,28 +68,36 @@ function getIconForControlLayer(url){
 }
 
 /**
- * Add a marker on the map with the style matching the type
- * @param type the type of shop
+ * Add a marker on the map with the style matching each type
+ * @param typeArray the types of shop
  * @param popup the text HTML formatted to display in the popup
  * @param lat the latitude of the marker
  * @param lon the longitude of the marker
  **/
-function addMarkerToMap(type, popup, lat, lon) {
-    // Create icon depending on the shop type
-    var icon = {icon: WorkshopEnum.properties[type].icon};
-
-    // Add marker and popup to the cluser
-    var marker = L.marker(new L.latLng(lat,lon), icon)
-        .bindPopup(popup)
-        .addTo(WorkshopEnum.properties[type].group);
+function addMarkerToMap(typeArray, popup, lat, lon) {
+    typeArray.forEach(function(item, index, array) {
+    	// Create icon depending on the shop type
+	    var icon = {icon: WorkshopEnum.properties[item].icon};
+	    // Add marker and popup to the cluser
+	    L.marker(new L.latLng(lat,lon), icon)
+	        .bindPopup(popup)
+	        .addTo(WorkshopEnum.properties[item].group);
+	});
 }
 
 /**
- * Get a title describing the shop type
+ * Get a title describing the shop types
  */
-function getShopTitle(type, collaborative_repair_shopTag) {
+function getShopTitle(typeArray, collaborative_repair_shopTag) {
     // Start text with italic style and add prefix depending on type
-    var title = WorkshopEnum.properties[type].titlePrefix;
+    var title = "";
+    typeArray.forEach(function(item, index, array) {
+      if (index > 0) {
+      	title += ", ";
+      }
+
+	  title += WorkshopEnum.properties[item].titlePrefix;
+	});
 
 	/*
     // Add annotation if products are organics
@@ -152,41 +160,41 @@ function getReadableHours(opening_hours){
 
 
 /**
- * Get the type of repair workshop
+ * Get the types of repair workshop
  */
  function getTypeRepair(fabrik, bicycle, camera, computers, fabrik, furniture, small_electronics_device) {
-    var type = null;
+    var typeArray = [];
 
-	var nbKindOfRepair=0;
-	if (fabrik=="yes")    { nbKindOfRepair++; }
-	if (furniture=="yes") { nbKindOfRepair++; }
-	if (computers=="yes") { nbKindOfRepair++; }
-	if (camera=="yes") { nbKindOfRepair++; }
-	if (bicycle=="yes") { nbKindOfRepair++; }
-	if (small_electronics_device=="yes") { nbKindOfRepair++; }
 
-	if (nbKindOfRepair>1) {
-		type = WorkshopEnum.REPAIR;
-	} else if (fabrik=="yes") {
-		type = WorkshopEnum.FABRIK;
-	} else if (furniture=="yes") {
-		type = WorkshopEnum.FURNITURE;
-	} else if (computers=="yes") {
-		type = WorkshopEnum.COMPUTERS;
-	} else if (camera=="yes") {
-		type = WorkshopEnum.CAMERA;
-	} else if (bicycle=="yes") {
-		type = WorkshopEnum.BICYCLE;
-	} else if (small_electronics_device=="yes") {
-		type = WorkshopEnum.SMALLELECTRONICSDEVICES;
+	if (fabrik=="yes") {
+		typeArray.push(WorkshopEnum.FABRIK);
+	} 
+
+	if (furniture=="yes") {
+		typeArray.push(WorkshopEnum.FURNITURE);
+	} 
+
+	if (computers=="yes") {
+		typeArray.push(WorkshopEnum.COMPUTERS);
+	} 
+
+	if (camera=="yes") {
+		typeArray.push(WorkshopEnum.CAMERA);
+	} 
+
+	if (bicycle=="yes") {
+		typeArray.push(WorkshopEnum.BICYCLE);
+	} 
+
+	if (small_electronics_device=="yes") {
+		typeArray.push(WorkshopEnum.SMALLELECTRONICSDEVICES);
 	}
 
-    if (!type) {
+    if (typeArray.length == 0) {
         console.log("Unknown shop type with name="+name+" ; shopTag="+shopTag+" ; craftTag="+craftTag+" and amenityTag="+amenityTag+ " ; type="+type);
-        type = null;
     }
 
-    return type;
+    return typeArray;
  }
 /**
  * Parse a shop tag into a WorkshopEnum

--- a/vracanantes.js
+++ b/vracanantes.js
@@ -81,7 +81,7 @@ function addListOfShops() {
 		}
 
 		// Get the type of shop/amenity to manage
-		var type = getTypeRepair(repairTags['service:fabrik:repair'],
+		var typeArray = getTypeRepair(repairTags['service:fabrik:repair'],
 			repairTags['service:bicycle:repair'],
 			repairTags['service:camera:repair'],
 			repairTags['service:computer:repair'],
@@ -89,7 +89,8 @@ function addListOfShops() {
 			repairTags['service:furniture:repair'],
 			repairTags['service:small_electronics_device:repair']);
 
-		if (!type) {
+		// Check if there is at least one type matching
+		if (typeArray == 0) {
 			continue;
 		}
 
@@ -109,12 +110,12 @@ function addListOfShops() {
 				repairTags['contact:website'],
 				repairTags['website'],
 				repairTags['description:fr'],
-				type
+				typeArray
 		);
 
 		// Check that popup has been correctly created
 		if (popup && lat && lon) {
-			addMarkerToMap(type, popup, lat, lon);
+			addMarkerToMap(typeArray, popup, lat, lon);
 		}
 	}
 }
@@ -137,7 +138,7 @@ function getPopupContent(
 		website,
 		website2,
 		description,
-		type
+		typeArray
 ){
 	// Check that name exists
 	if (!name) {
@@ -146,7 +147,7 @@ function getPopupContent(
 	var popup = '<b>'+name+'</b><br />';
 
 	// Set the shop type
-	var shopTitle = getShopTitle(type, collaborative_repair_shop);
+	var shopTitle = getShopTitle(typeArray, collaborative_repair_shop);
 	if (description) {
 		popup += '<i>'+description+'</i><br />';
 	}


### PR DESCRIPTION
This pull request will allow to catch all types of a given repair shop. For each type a marker will be displayed on the map with a different sub-group layer. 

This means that a repair shop can have multiple markers. Is that what you wanted?